### PR TITLE
Temporarily add `CMAKE_SYSTEM_PROCESSOR` override

### DIFF
--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -12,7 +12,7 @@ cd $WORKSPACE/srcdir/c-blosc
 
 mkdir build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=/opt/$target/$target.toolchain -DBUILD_TESTS=Off -DBUILD_BENCHMARKS=Off ..
+cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=/opt/$target/$target.toolchain -DBUILD_TESTS=Off -DBUILD_BENCHMARKS=Off -DCMAKE_SYSTEM_PROCESSOR=$(uname -p) ..
 make && make install
 """
 


### PR DESCRIPTION
This is a stopgap measure until https://github.com/staticfloat/julia-docker/commit/4bb8f656c90c74c3f6f503bce9656c6278ba9b9a hits a mainstream rootfs release